### PR TITLE
fix tmux_tree pattern match can match multiple sessions, closes #22

### DIFF
--- a/config/tmux/tmux_tree
+++ b/config/tmux/tmux_tree
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 tmux ls -F'#{session_id}' | while read -r s; do
-    S=$(tmux ls -F'#{session_id}#{session_name}: #{T:tree_mode_format}' | grep ^"$s")
-    session_info=${S##$s}
+    S=$(tmux ls -F'#{session_id}:#{session_name}: #{T:tree_mode_format}' | grep ^"$s:")
+    session_info=${S##$s:}
     session_name=$(echo "$session_info" | cut -d ':' -f 1)
-    if [[ -n "$1" ]] && [[ "$1" == "$session_name" ]]; then
+    if [[ "$1" == "$session_name" ]]; then
         echo -e "\033[1;34m$session_info\033[0m"
     else
         echo -e "\033[1m$session_info\033[0m"


### PR DESCRIPTION
Rather than using the space (` `) character as the separator, I chose to use the colon (`:`) character, since this cannot be included in a tmux session name.